### PR TITLE
Run gradle inside docker container

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - jamie/BICAWS-1801-update-b7-standing-data-prs
     paths:
       - 'output-data/**'
       - '.github/workflows/**'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - jamie/BICAWS-1801-update-b7-standing-data-prs
     paths:
       - 'output-data/**'
       - '.github/workflows/**'
@@ -94,7 +93,7 @@ jobs:
         with:
           java-version: 17
       - name: Update standing data maven package
-        run: gradle classes --no-daemon --parallel --update-locks *:bichard7-next-data
+        run: docker-compose run app gradle classes --no-daemon --parallel -g gradle-home --update-locks *:bichard7-next-data
       - name: Create pull request
         id: cpr
         uses: peter-evans/create-pull-request@v4


### PR DESCRIPTION
This PR changes the call to gradle that updates the dependencies in bichard7-next to run inside the gradle container from bichard7-next.

This will not only help to keep the gradle version we use everywhere consistent, but it's also seemingly the only way of running it.