### PR TITLE
Include zero codes

### DIFF
--- a/input-data/organisation-unit/zero-codes.json
+++ b/input-data/organisation-unit/zero-codes.json
@@ -1,0 +1,79 @@
+[
+  {
+    "bottomLevelCode": "00",
+    "bottomLevelName": "",
+    "secondLevelCode": "00",
+    "secondLevelName": "",
+    "thirdLevelCode": "00",
+    "thirdLevelName": "",
+    "thirdLevelPsaCode": "",
+    "topLevelCode": "B",
+    "topLevelName": ""
+  },
+  {
+    "bottomLevelCode": "00",
+    "bottomLevelName": "",
+    "secondLevelCode": "00",
+    "secondLevelName": "",
+    "thirdLevelCode": "00",
+    "thirdLevelName": "",
+    "thirdLevelPsaCode": "",
+    "topLevelCode": "C",
+    "topLevelName": "Crown Courts"
+  },
+  {
+    "bottomLevelCode": "00",
+    "bottomLevelName": "",
+    "secondLevelCode": "00",
+    "secondLevelName": "Athena Forces",
+    "thirdLevelCode": "XX",
+    "thirdLevelName": "ATHENA NON RECORDABLE TRAFFIC CASES",
+    "thirdLevelPsaCode": "",
+    "topLevelCode": "",
+    "topLevelName": "Police Service"
+  },
+  {
+    "bottomLevelCode": "00",
+    "bottomLevelName": "",
+    "secondLevelCode": "00",
+    "secondLevelName": "Non Police Prosecutor",
+    "thirdLevelCode": "NP",
+    "thirdLevelName": "",
+    "thirdLevelPsaCode": "",
+    "topLevelCode": "",
+    "topLevelName": "Police Service"
+  },
+  {
+    "bottomLevelCode": "00",
+    "bottomLevelName": "",
+    "secondLevelCode": "00",
+    "secondLevelName": "Police",
+    "thirdLevelCode": "00",
+    "thirdLevelName": "",
+    "thirdLevelPsaCode": "",
+    "topLevelCode": "",
+    "topLevelName": "Police Service"
+  },
+  {
+    "bottomLevelCode": "00",
+    "bottomLevelName": "",
+    "secondLevelCode": "00",
+    "secondLevelName": "Unknown Force Prosecutor",
+    "thirdLevelCode": "PP",
+    "thirdLevelName": "",
+    "thirdLevelPsaCode": "",
+    "topLevelCode": "",
+    "topLevelName": "Police Service"
+  },
+  {
+    "bottomLevelCode": "00",
+    "bottomLevelName": "",
+    "secondLevelCode": "00",
+    "secondLevelName": "Unknown Force Prosecutor - CC records",
+    "thirdLevelCode": "OO",
+    "thirdLevelName": "",
+    "thirdLevelPsaCode": "",
+    "topLevelCode": "",
+    "topLevelName": "Police Service"
+  }
+]

--- a/output-data/data/organisation-unit.json
+++ b/output-data/data/organisation-unit.json
@@ -2,6 +2,83 @@
   {
     "bottomLevelCode": "00",
     "bottomLevelName": "",
+    "secondLevelCode": "00",
+    "secondLevelName": "",
+    "thirdLevelCode": "00",
+    "thirdLevelName": "",
+    "thirdLevelPsaCode": "",
+    "topLevelCode": "B",
+    "topLevelName": ""
+  },
+  {
+    "bottomLevelCode": "00",
+    "bottomLevelName": "",
+    "secondLevelCode": "00",
+    "secondLevelName": "",
+    "thirdLevelCode": "00",
+    "thirdLevelName": "",
+    "thirdLevelPsaCode": "",
+    "topLevelCode": "C",
+    "topLevelName": "Crown Courts"
+  },
+  {
+    "bottomLevelCode": "00",
+    "bottomLevelName": "",
+    "secondLevelCode": "00",
+    "secondLevelName": "Athena Forces",
+    "thirdLevelCode": "XX",
+    "thirdLevelName": "ATHENA NON RECORDABLE TRAFFIC CASES",
+    "thirdLevelPsaCode": "",
+    "topLevelCode": "",
+    "topLevelName": "Police Service"
+  },
+  {
+    "bottomLevelCode": "00",
+    "bottomLevelName": "",
+    "secondLevelCode": "00",
+    "secondLevelName": "Non Police Prosecutor",
+    "thirdLevelCode": "NP",
+    "thirdLevelName": "",
+    "thirdLevelPsaCode": "",
+    "topLevelCode": "",
+    "topLevelName": "Police Service"
+  },
+  {
+    "bottomLevelCode": "00",
+    "bottomLevelName": "",
+    "secondLevelCode": "00",
+    "secondLevelName": "Police",
+    "thirdLevelCode": "00",
+    "thirdLevelName": "",
+    "thirdLevelPsaCode": "",
+    "topLevelCode": "",
+    "topLevelName": "Police Service"
+  },
+  {
+    "bottomLevelCode": "00",
+    "bottomLevelName": "",
+    "secondLevelCode": "00",
+    "secondLevelName": "Unknown Force Prosecutor",
+    "thirdLevelCode": "PP",
+    "thirdLevelName": "",
+    "thirdLevelPsaCode": "",
+    "topLevelCode": "",
+    "topLevelName": "Police Service"
+  },
+  {
+    "bottomLevelCode": "00",
+    "bottomLevelName": "",
+    "secondLevelCode": "00",
+    "secondLevelName": "Unknown Force Prosecutor - CC records",
+    "thirdLevelCode": "OO",
+    "thirdLevelName": "",
+    "thirdLevelPsaCode": "",
+    "topLevelCode": "",
+    "topLevelName": "Police Service"
+  },
+  {
+    "bottomLevelCode": "00",
+    "bottomLevelName": "",
     "secondLevelCode": "01",
     "secondLevelName": "Metropolitan Police Service",
     "thirdLevelCode": "",

--- a/output-data/package.json
+++ b/output-data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moj-bichard7-developers/bichard7-next-data",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "description": "The standing data for Bichard",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
         output-data/package.json and written to `version.properties` - where it is then read by
         maven.
     -->
-    <version>2.0.11</version>
+    <version>2.0.13</version>
     <packaging>jar</packaging>
 
     <name>bichard7-next-data</name>

--- a/src/download-organisation-unit-data.ts
+++ b/src/download-organisation-unit-data.ts
@@ -1,23 +1,23 @@
 /* eslint-disable no-console */
 /* eslint-disable import/no-relative-packages */
-import fs from "fs"
+// import fs from "fs"
 import organisationUnitDownload from "./organisation-unit-download"
-import forces from "../output-data/data/forces.json"
-import consistentSort from "./lib/consistentSort"
-import generatePoliceOrganisationUnits from "./organisation-unit-download/generatePoliceOrganisationUnits"
-
-const spreasheetData = fs.readFileSync("input-data/organisation-unit/INC275907.UT400J.FSCODES.xlsx")
+// import forces from "../output-data/data/forces.json"
+// import consistentSort from "./lib/consistentSort"
+// import generatePoliceOrganisationUnits from "./organisation-unit-download/generatePoliceOrganisationUnits"
+//
+// const spreasheetData = fs.readFileSync("input-data/organisation-unit/INC275907.UT400J.FSCODES.xlsx")
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
-const reGeneratePoliceOrganisationUnits = async () => {
-  const policeOrgUnits = generatePoliceOrganisationUnits(spreasheetData, forces)
-  const sortedData = consistentSort(policeOrgUnits)
-
-  await fs.promises.writeFile(
-    "input-data/organisation-unit/police-forces.json",
-    JSON.stringify(sortedData, null, 2)
-  )
-}
+// const reGeneratePoliceOrganisationUnits = async () => {
+//  const policeOrgUnits = generatePoliceOrganisationUnits(spreasheetData, forces)
+//  const sortedData = consistentSort(policeOrgUnits)
+//
+//  await fs.promises.writeFile(
+//    "input-data/organisation-unit/police-forces.json",
+//    JSON.stringify(sortedData, null, 2)
+//  )
+// }
 
 const main = async () => {
   // await reGeneratePoliceOrganisationUnits()

--- a/src/organisation-unit-download/index.ts
+++ b/src/organisation-unit-download/index.ts
@@ -9,6 +9,7 @@ import generateCourtOrganisationUnits from "./generateCourtOrganisationUnits"
 import backFillThirdLevelPsaCode from "./backFillThirdLevelPsaCode"
 import { OrganisationUnit } from "../types/OrganisationUnit"
 import policeOrganisationUnitData from "../../input-data/organisation-unit/police-forces.json"
+import zeroCodes from "../../input-data/organisation-unit/zero-codes.json"
 
 export default async () => {
   console.log("Downloading Organisation Unit data")
@@ -21,7 +22,8 @@ export default async () => {
     existingOrganisationUnitData as OrganisationUnit[]
   )
   const allOrganisationUnitData = courtOrganisationUnitDataWithPsaCode.concat(
-    policeOrganisationUnitData
+    policeOrganisationUnitData,
+    zeroCodes
   )
   const data = consistentSort(allOrganisationUnitData)
   await fs.promises.writeFile(


### PR DESCRIPTION
e2e tests were failing because a 00 ASN was considered as invalid, we are adding them back in until we can confirm that these 00 codes are not actually used in production.