### PR TITLE
fix: 🐛 bichard core is expecting this type

### DIFF
--- a/output-data/package.json
+++ b/output-data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@moj-bichard7-developers/bichard7-next-data",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "description": "The standing data for Bichard",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/output-data/types/types.ts
+++ b/output-data/types/types.ts
@@ -84,6 +84,7 @@ export type OrganisationUnit = {
   secondLevelName?: string
   thirdLevelCode: string
   thirdLevelName?: string
+  thirdLevelPsaCode: string
   topLevelCode: string
   topLevelName: string
 }

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
         output-data/package.json and written to `version.properties` - where it is then read by
         maven.
     -->
-    <version>2.0.15</version>
+    <version>2.0.16</version>
     <packaging>jar</packaging>
 
     <name>bichard7-next-data</name>


### PR DESCRIPTION
see [line 90 `src/use-cases/dataLookup/dataLookup.ts` in `bichard7-next-core` ](https://github.com/ministryofjustice/bichard7-next-core/blob/237658501bbfbc5b9c831edfd2748c7985e4c404/src/use-cases/dataLookup/dataLookup.ts#L90)

It was accidentally removed in this PR https://github.com/ministryofjustice/bichard7-next-data/pull/48/files see `output-data/types/types.ts`