### PR TITLE
Tweak pushing of version bump from CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GH_ACCESS_TOKEN }}
+          persist-credentials: true
 
       - name: Setup Node.js
         uses: actions/setup-node@v2
@@ -43,7 +46,9 @@ jobs:
           git add output-data/package*.json pom.xml
           git commit -m "Bump package version"
           git tag v${{ steps.bump.outputs.version }}
-          git push --follow-tags
+
+      - name: Push new commit and tag
+        run: git push --follow-tags
 
   release-npm-package:
     name: Release NPM package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
           git config user.name ${{ env.GITHUB_USERNAME }}
           git config user.email ${{ env.GITHUB_EMAIL }}
           git add output-data/package*.json pom.xml
-          git commit -m "Bump package version"
+          git commit -m "Bump package version [skip actions]"
           git tag v${{ steps.bump.outputs.version }}
 
       - name: Push new commit and tag


### PR DESCRIPTION
This PR makes a couple of tweaks to the way that the data version number is pushed from the CI:

 - It caches the @bichard7 user's access token with the `actions/checkout` action, so that when we later push it uses the same token (rather than the default token assigned to the workflow run, which does not have push access)
 - It adds a `[skip actions]` string to the end of the version bump commit message, so that it doesn't trigger the same release workflow to run again when it's pushed, and thus cause an indefinite cycle of version bumps