### PR TITLE
Update release.yml for core data dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,7 +148,9 @@ jobs:
           token: ${{ secrets.GH_ACCESS_TOKEN }}
 
       - name: Update standing data npm package
-        run: npm install @moj-bichard7-developers/bichard7-next-data@${VERSION}
+        run: npm install \
+          bichard7-next-data-${VERSION}@npm:@moj-bichard7-developers/bichard7-next-data@${VERSION} \
+          bichard7-next-data-latest@npm:@moj-bichard7-developers/bichard7-next-data@${VERSION}
         env:
           VERSION: ${{ needs.bump-package-version.outputs.version }}
 


### PR DESCRIPTION
Updated the update-core-repo step to install the new standing data npm package using a new alias.

Previously, the new standing data package was installed using its actual name in `package.json`:
e.g.
```
    "@moj-bichard7-developers/bichard7-next-data": "^2.0.22",
```

We changed Core repo to install all standing data packages (>2.0.20) with different aliases. So the above package name is not used anywhere in Core repo.

This PR updates the github action (release.yml) to use a new alias for the package and also updates the latest standing data package in core to point to the new data version when creating a PR:
e.g.
```
    "bichard7-next-data-2.0.22": "npm:@moj-bichard7-developers/bichard7-next-data@^2.0.22",
    "bichard7-next-data-latest": "npm:@moj-bichard7-developers/bichard7-next-data@^2.0.22",
```