### PR TITLE
Fix steps to bump data package version in gradle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,7 +191,7 @@ jobs:
 
       - name: Update standing data gradle dependency
         run: |
-          sed -i -r "s/name: 'bichard7-next-data', version: '[0-9]+\.[0-9]+\.[0-9]+'$/name: 'bichard7-next-data', version: '$VERSION'/g" bichard-backend/build.gradle
+          sed -i -r "s/bichardDataVersion = \"[0-9]+\.[0-9]+\.[0-9]+\"$/bichardDataVersion = \"$VERSION\"/g" build.gradle
         env:
           VERSION: ${{ needs.bump-package-version.outputs.version }}
 


### PR DESCRIPTION
The way the dependency is declared changed in https://github.com/ministryofjustice/bichard7-next/commit/aa0d9fe667dc58ac0fd0c67d46c8e7b70312c263 and currently doesn't work, https://github.com/ministryofjustice/bichard7-next-data/runs/8248096215 shows no diffs to commit

This PR updates the sed command used to update the gradle dependency, which is now listed in https://github.com/ministryofjustice/bichard7-next/blob/686f0712be35de1de9289dc326074c0acfb7abec/build.gradle#L9