### PR TITLE
Fix update standing data workflow

### DIFF
--- a/.github/workflows/update-npm-deps.yml
+++ b/.github/workflows/update-npm-deps.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup node version
         uses: actions/setup-node@v2
         with:
-          node-version: 16.3.0
+          node-version: 16.13.1
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/update-standing-data.yml
+++ b/.github/workflows/update-standing-data.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup node version
         uses: actions/setup-node@v2
         with:
-          node-version: 16.3.0
+          node-version: 16.13.1
 
       - name: Install dependencies
         run: npm install

--- a/src/pnld-download/PnldFileDownloader.ts
+++ b/src/pnld-download/PnldFileDownloader.ts
@@ -1,18 +1,18 @@
 /* eslint-disable no-await-in-loop */
 import * as fs from "fs"
-import puppeteer from "puppeteer"
+import puppeteer, { ElementHandle, Browser, Page } from "puppeteer"
 import { PnldConfig } from "./config"
 
 export type PnldFile = {
   date: Date
-  link?: puppeteer.ElementHandle | null
+  link?: ElementHandle | null
   fileName?: string
 }
 
 export default class PnldFileDownloader {
-  browser: puppeteer.Browser
+  browser: Browser
 
-  page: puppeteer.Page
+  page: Page
 
   tmpDir: string
 
@@ -89,7 +89,7 @@ export default class PnldFileDownloader {
     }
   }
 
-  async downloadFile(link: puppeteer.ElementHandle): Promise<string> {
+  async downloadFile(link: ElementHandle): Promise<string> {
     const before = await fs.promises.readdir(this.tmpDir)
     await link.click()
     await this.waitForZipCount(before.length + 1, 60)


### PR DESCRIPTION
Puppeteer changed to a new module format in 19.3.0, and some classes need to be imported explicitly, see https://github.com/puppeteer/puppeteer/issues/9417

Also set all github actions to use the same version of node as in `.nvmrc`, that being node `16.13.1`