### PR TITLE
Add short description to trigger definitions

### DIFF
--- a/output-data/data/trigger-definitions.json
+++ b/output-data/data/trigger-definitions.json
@@ -1,138 +1,172 @@
 [
     {
         "code": "TRPR0001",
-        "description": "Driver Disqualification - Update DD screen."
+        "description": "Driver Disqualification - Update DD screen.",
+        "shortDescription": "Disqualified driver"
     },
     {
         "code": "TRPR0002",
-        "description": "Warrant issued - Update Wanted/Missing"
+        "description": "Warrant issued - Update Wanted/Missing",
+        "shortDescription": "Warrant issued"
     },
     {
         "code": "TRPR0003",
-        "description": "Order Issues - Update Wanted/Missing, check and amend Disposal"
+        "description": "Order Issues - Update Wanted/Missing, check and amend Disposal",
+        "shortDescription": "Order issues"
     },
     {
         "code": "TRPR0004",
-        "description": "Convicted of Sexual Offence or Sexual Order made - Update Markers and Register(s) as appropriate"
+        "description": "Convicted of Sexual Offence or Sexual Order made - Update Markers and Register(s) as appropriate",
+        "shortDescription": "Sex offender"
     },
     {
         "code": "TRPR0005",
-        "description": "Defendant remanded in custody - update custody history"
+        "description": "Defendant remanded in custody - update custody history",
+        "shortDescription": "Remand in custody"
     },
     {
         "code": "TRPR0006",
-        "description": "Defendant imprisoned - update custody history"
+        "description": "Defendant imprisoned - update custody history",
+        "shortDescription": "Imprisoned"
     },
     {
         "code": "TRPR0007",
-        "description": "Defendant dead - update death marker"
+        "description": "Defendant dead - update death marker",
+        "shortDescription": "Defendant dead"
     },
     {
         "code": "TRPR0008",
-        "description": "Defendant has breached bail - Update breach of bail marker"
+        "description": "Defendant has breached bail - Update breach of bail marker",
+        "shortDescription": "Breach of bail"
     },
     {
         "code": "TRPR0010",
-        "description": "Bail conditions imposed/varied/cancelled - update remand screen"
+        "description": "Bail conditions imposed/varied/cancelled - update remand screen",
+        "shortDescription": "Conditional bail"
     },
     {
         "code": "TRPR0012",
-        "description": "Warrant not executed/Withdrawn - update Wanted/Missing screen"
+        "description": "Warrant not executed/Withdrawn - update Wanted/Missing screen",
+        "shortDescription": "Warrant withdrawn"
     },
     {
         "code": "TRPR0014",
-        "description": "Too many offences - manual update"
+        "description": "Too many offences - manual update",
+        "shortDescription": "Too many offences"
     },
     {
         "code": "TRPR0015",
-        "description": "Personal details changed"
+        "description": "Personal details changed",
+        "shortDescription": "Personal details changed"
     },
     {
         "code": "TRPR0016",
-        "description": "Forfeiture order made - update records as appropriate"
+        "description": "Forfeiture order made - update records as appropriate",
+        "shortDescription": "Forfeiture order"
     },
     {
         "code": "TRPR0017",
-        "description": "Adjourned Sine Die - update case details"
+        "description": "Adjourned Sine Die - update case details",
+        "shortDescription": "Adjourned sine die"
     },
     {
         "code": "TRPR0018",
-        "description": "Update offence date(s) on PNC"
+        "description": "Update offence date(s) on PNC",
+        "shortDescription": "Update offence dates"
     },
     {
         "code": "TRPR0019",
-        "description": "Remanded in custody with bail direction"
+        "description": "Remanded in custody with bail direction",
+        "shortDescription": "Bail direction"
     },
     {
         "code": "TRPR0020",
-        "description": "Update original case with conviction and sentence details"
+        "description": "Update original case with conviction and sentence details",
+        "shortDescription": "Breach"
     },
     {
         "code": "TRPR0021",
-        "description": "Disqualification or Revocation Order made (not motoring)"
+        "description": "Disqualification or Revocation Order made (not motoring)",
+        "shortDescription": "Disq. non-motoring"
     },
     {
         "code": "TRPR0022",
-        "description": "Extradition ordered or Proceedings pending"
+        "description": "Extradition ordered or Proceedings pending",
+        "shortDescription": "Extradition order"
     },
     {
         "code": "TRPR0023",
-        "description": "Domestic Violence Case"
+        "description": "Domestic Violence Case",
+        "shortDescription": "Domestic violence"
     },
     {
         "code": "TRPR0024",
-        "description": "Vulnerable or Intimidated victim/witness"
+        "description": "Vulnerable or Intimidated victim/witness",
+        "shortDescription": "Vulnerable victim"
     },
     {
         "code": "TRPR0025",
-        "description": "Original case has been re-opened/stat dec made - check new sentence details"
+        "description": "Original case has been re-opened/stat dec made - check new sentence details",
+        "shortDescription": "Case reopened"
     },
     {
         "code": "TRPR0026",
-        "description": "Driving disqualification suspended"
+        "description": "Driving disqualification suspended",
+        "shortDescription": "Disq. Suspended"
     },
     {
         "code": "TRPR0027",
-        "description": "Out of Area case"
+        "description": "Out of Area case",
+        "shortDescription": "Out of Area case"
     },
     {
         "code": "TRPR0028",
-        "description": "Trigger only case reallocated from another force"
+        "description": "Trigger only case reallocated from another force",
+        "shortDescription": "Trigger case reallocated"
     },
     {
         "code": "TRPR0029",
-        "description": "Civil proceedings granted or Order made - update records as appropriate"
+        "description": "Civil proceedings granted or Order made - update records as appropriate",
+        "shortDescription": "Civil Proceedings"
     },
     {
         "code": "TRPR0030",
-        "description": "Pre-charge bail application"
+        "description": "Pre-charge bail application",
+        "shortDescription": "Pre-charge bail application"
     },
     {
         "code": "TRPS0002",
-        "description": "Confirm address on PNC"
+        "description": "Confirm address on PNC",
+        "shortDescription": "Check address"
     },
     {
         "code": "TRPS0003",
-        "description": "Disposal text was truncated - revise on PNC if wanted"
+        "description": "Disposal text was truncated - revise on PNC if wanted",
+        "shortDescription": "Disposal text truncated"
     },
     {
         "code": "TRPS0004",
-        "description": "Split Adjournment - manual split required"
+        "description": "Split Adjournment - manual split required",
+        "shortDescription": "Split adjournment"
     },
     {
         "code": "TRPS0008",
-        "description": "Enter details of curfew order"
+        "description": "Enter details of curfew order",
+        "shortDescription": "Curfew order"
     },
     {
         "code": "TRPS0010",
-        "description": "Offence added to the PNC - Update MO Screen/Offence Location/Update 3042"
+        "description": "Offence added to the PNC - Update MO Screen/Offence Location/Update 3042",
+        "shortDescription": "Offence added to PNC"
     },
     {
         "code": "TRPS0011",
-        "description": "Offence added at court - add to PNC"
+        "description": "Offence added at court - add to PNC",
+        "shortDescription": "Add offence to PNC"
     },
     {
         "code": "TRPS0013",
-        "description": "Offences taken into consideration - add to offence"
+        "description": "Offences taken into consideration - add to offence",
+        "shortDescription": "Offence(s) TIC"
     }
 ]


### PR DESCRIPTION
### Context
B7 displays a short description of triggers in the reason field, these are hardcoded in the [ApplicationResources](https://github.com/ministryofjustice/bichard7-next/blob/main/bichard-backend/src/main/resources/ApplicationResources.properties#L1012) file. Adding these to the existing trigger definitions, we can display descriptions on the new case list using the standing data library.

### Changes
- Add a short description to trigger definitions in [output-data/data/trigger-definitions.json](https://github.com/ministryofjustice/bichard7-next-data/compare/Add-short-description-to-trigger-definitions?expand=1#diff-c7a963fab26d3cc26d58cc10f9f7bc80a478d98e0d775ac99f3187d31d16ab9f)