### PR TITLE
Fixed schema validation error

### DIFF
--- a/src/schemas/standingDataAPIResult.ts
+++ b/src/schemas/standingDataAPIResult.ts
@@ -1,7 +1,7 @@
 import { z } from "zod"
 
 export const apiOffenceSchema = z.object({
-  Code: z.string(),
+  code: z.string(),
   OffenceType: z.string().optional(),
   CjsTitle: z.string().optional()
 })

--- a/src/standing-data-gateway/convertApiResponse.ts
+++ b/src/standing-data-gateway/convertApiResponse.ts
@@ -6,7 +6,7 @@ export default (apiResponse: ApiOffence[] | Error): OffenceCode[] => {
     throw new Error("apiResponse resulted in Error output")
   }
   return apiResponse.map((offenceCode) => ({
-    cjsCode: offenceCode.Code,
+    cjsCode: offenceCode.code,
     offenceTitle: offenceCode.CjsTitle,
     offenceCategory: offenceCode.OffenceType,
     resultHalfLifeHours: null

--- a/src/standing-data-gateway/getOffence.ts
+++ b/src/standing-data-gateway/getOffence.ts
@@ -51,7 +51,9 @@ const getOffence = async (alphaChar: string): Promise<ApiOffence[] | Error> => {
       return newResult
     })
     .catch((error) => {
+      const reducedErrorOutput = error.issues[0]
       console.log(`error with ${alphaChar}`)
+      console.log(reducedErrorOutput)
       return error
     })
 }


### PR DESCRIPTION
Github action failed this morning, there seems to be some working going on in the background. 3 weeks ago we had to fix the Zod schema, the attribute `code` was changed to `Code` which led to a Zod error. It seems today that it has switched back to lower case `code`. 

We have added a extra error log and just grabbing the first error so we can debug quicker
