### PR TITLE
Fix PNLD file downloads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@typescript-eslint/eslint-plugin": "^5.59.1",
         "@typescript-eslint/parser": "^5.59.1",
         "axios": "^1.4.0",
+        "date-fns": "^2.30.0",
         "eslint": "^8.39.0",
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-config-airbnb-typescript": "^17.0.0",
@@ -1887,6 +1888,17 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.5.tgz",
+      "integrity": "sha512-8jI69toZqqcsnqGGqwGS4Qb1VwLOEp4hz+CXPywcvjs60u3B4Pom/U/7rm4W8tMOYEB+E9wgD0mW1l3r8qlI9Q==",
+      "dependencies": {
+        "regenerator-runtime": "^0.13.11"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -4351,6 +4363,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
       }
     },
     "node_modules/debug": {
@@ -9485,6 +9512,11 @@
         "node": ">= 6"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
@@ -12659,6 +12691,14 @@
         "@babel/helper-plugin-utils": "^7.19.0"
       }
     },
+    "@babel/runtime": {
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.5.tgz",
+      "integrity": "sha512-8jI69toZqqcsnqGGqwGS4Qb1VwLOEp4hz+CXPywcvjs60u3B4Pom/U/7rm4W8tMOYEB+E9wgD0mW1l3r8qlI9Q==",
+      "requires": {
+        "regenerator-runtime": "^0.13.11"
+      }
+    },
     "@babel/template": {
       "version": "7.20.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.20.7.tgz",
@@ -14450,6 +14490,14 @@
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
           "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
         }
+      }
+    },
+    "date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "requires": {
+        "@babel/runtime": "^7.21.0"
       }
     },
     "debug": {
@@ -18124,6 +18172,11 @@
         "string_decoder": "^1.1.1",
         "util-deprecate": "^1.0.1"
       }
+    },
+    "regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "regexp.prototype.flags": {
       "version": "1.4.3",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@typescript-eslint/eslint-plugin": "^5.59.1",
     "@typescript-eslint/parser": "^5.59.1",
     "axios": "^1.4.0",
+    "date-fns": "^2.30.0",
     "eslint": "^8.39.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-airbnb-typescript": "^17.0.0",

--- a/src/pnld-download/PnldFileDownloader.ts
+++ b/src/pnld-download/PnldFileDownloader.ts
@@ -101,7 +101,7 @@ export default class PnldFileDownloader {
 
   async getFileLinks(): Promise<PnldFile[]> {
     const links: PnldFile[] = []
-    await this.page.goto(this.options.downloadUrl)
+    await this.page.goto(this.options.downloadUrl, { waitUntil: "networkidle2" })
     // The links are in a 4 column table with the date in the 1st column and the link in the second
     const columnCount = 4
     const tds = await this.page.$$(".table-responsive table tbody td")

--- a/src/pnld-download/PnldFileDownloader.ts
+++ b/src/pnld-download/PnldFileDownloader.ts
@@ -26,7 +26,7 @@ export default class PnldFileDownloader {
   async setupPuppeteer(): Promise<void> {
     this.browser = await puppeteer.launch({
       ignoreHTTPSErrors: true,
-      headless: this.options.headless,
+      headless: this.options.headless ? "new" : undefined,
       args: [
         // Required for Docker version of Puppeteer
         "--no-sandbox",

--- a/src/pnld-download/PnldFileDownloader.ts
+++ b/src/pnld-download/PnldFileDownloader.ts
@@ -75,8 +75,9 @@ export default class PnldFileDownloader {
 
   async waitForZipCount(zipCount: number, timeout: number): Promise<void> {
     for (let i = 0; i < timeout; i++) {
-      // eslint-disable-next-line no-promise-executor-return
-      await new Promise((res) => setTimeout(res, 1000))
+      await new Promise((res) => {
+        setTimeout(res, 1000)
+      })
       const dir = await fs.promises.readdir(this.tmpDir)
       const count = dir.reduce((acc, filename) => {
         if (filename.endsWith(".zip")) {
@@ -95,11 +96,8 @@ export default class PnldFileDownloader {
     const linkLocation = await link.evaluate((el) => el.getAttribute("href"))
     console.log(`Downloading PNLD file "${linkText}" from ${linkLocation}`)
 
-    await new Promise((r) => {
-      setTimeout(r, 2_000)
-    })
-
     const before = await fs.promises.readdir(this.tmpDir)
+    await link.scrollIntoView()
     await link.click()
     await this.waitForZipCount(before.length + 1, 60)
     const after = await fs.promises.readdir(this.tmpDir)
@@ -128,6 +126,11 @@ export default class PnldFileDownloader {
   async downloadArchives(): Promise<PnldFile[]> {
     await this.setupDownloadFolder()
     const fileLinks = await this.getFileLinks()
+
+    const cookiesButton = await this.page.$(".closeCookies")
+    if (cookiesButton) {
+      await cookiesButton.click()
+    }
 
     // eslint-disable-next-line no-restricted-syntax
     for (const fileLink of fileLinks) {

--- a/src/pnld-download/PnldFileDownloader.ts
+++ b/src/pnld-download/PnldFileDownloader.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-await-in-loop */
 import * as fs from "fs"
 import puppeteer, { ElementHandle, Browser, Page } from "puppeteer"
+import { parse } from "date-fns"
 import { PnldConfig } from "./config"
 
 export type PnldFile = {
@@ -108,7 +109,7 @@ export default class PnldFileDownloader {
     for (let i = 0; i < rowCount * columnCount; i += columnCount) {
       const date = await tds[i].evaluate((node) => (node as any).innerText)
       const link = await tds[i + 1].$("a")
-      links.push({ date: new Date(date), link })
+      links.push({ date: parse(date, "dd/MM/yy", new Date()), link })
     }
     return links
   }


### PR DESCRIPTION
The `Update standing data` action has been failing to download files from the PNLD portal. This was because puppeteer's clicks simulate a real click on the page where the element lies, and some of the links were being covered by a cookie banner:
![Screenshot 2023-05-05 at 13 11 48](https://user-images.githubusercontent.com/7249529/236455927-09d07e40-61c3-4782-8ea8-81fae11ba03e.png)


This PR:
* Dismisses the cookie banner on the download page
* Ensures that download links are scrolled into view
* Adds more logging around PNLD file downloads
* Uses the new puppeteer headless mode to dismiss a deprecation warning
* Waits until the download page is fully loaded to begin downloading files
* Fixes date parsing when retrieving download links