### PR TITLE
Removed command to download SD from API

### DIFF
--- a/.github/workflows/update-standing-data.yml
+++ b/.github/workflows/update-standing-data.yml
@@ -32,7 +32,7 @@ jobs:
         run: npm install
 
       - name: Download data files
-        run: npm run download-offence-code-data && npm run download-standing-data
+        run: npm run download-offence-code-data
 
       - name: Merge offence code data files
         run: npm run merge-offence-data


### PR DESCRIPTION
We have decided to disable the step where we were calling the SDRS (Standing Data & Reference Service) API as its not been fully integrated and doesn't seem like it will anytime soon. Quick win for now and keeps the alerts channel free from noise