### PR TITLE
Update release workflow to not install versioned package name in core

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,7 +151,6 @@ jobs:
       - name: Update standing data npm package
         run: >
           npm install 
-          bichard7-next-data-${VERSION}@npm:@moj-bichard7-developers/bichard7-next-data@${VERSION} 
           bichard7-next-data-latest@npm:@moj-bichard7-developers/bichard7-next-data@${VERSION}
         env:
           VERSION: ${{ needs.bump-package-version.outputs.version }}


### PR DESCRIPTION
We have updated the Core repo to not install historical standing data packages by default. This PR updates the release workflow to not install versioned data package in core.