### PR TITLE
Remove .vscode from git and add to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ target
 .idea
 output-data/data/triggers.properties
 *.xlsx
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-  "editor.wordWrap": "wordWrapColumn",
-  "editor.wordWrapColumn": 100,
-  "diffEditor.wordWrap": "on"
-}


### PR DESCRIPTION
Editor config files don't belong in git. Ideally we should all have a [global](https://sebastiandedeyne.com/setting-up-a-global-gitignore-file/) `.gitignore` configured to exclude `.vscode` (and `DS_Store`), but have added it to the repo `.gitignore` to avoid accidental re-committing.