### PR TITLE
Change attribute to use the new version

### DIFF
--- a/src/pnld-download/PnldFileDownloader.ts
+++ b/src/pnld-download/PnldFileDownloader.ts
@@ -25,7 +25,7 @@ export default class PnldFileDownloader {
 
   async setupPuppeteer(): Promise<void> {
     this.browser = await puppeteer.launch({
-      ignoreHTTPSErrors: true,
+      acceptInsecureCerts: true,
       headless: this.options.headless,
       args: [
         // Required for Docker version of Puppeteer


### PR DESCRIPTION
This PR updates one of the attributes we use when running puppeteer 
https://github.com/puppeteer/puppeteer/releases/tag/puppeteer-core-v23.0.0