### PR TITLE
Fix CJS offence data download

### DIFF
--- a/src/cjs-download/convertOds.ts
+++ b/src/cjs-download/convertOds.ts
@@ -20,10 +20,12 @@ export default (data: Buffer): OffenceCode[] => {
 
   const worksheet = workbook.Sheets[workbook.SheetNames[0]]
   const jsonWorksheet: CjsOffenceCode[] = XLSX.utils.sheet_to_json(worksheet)
-  return jsonWorksheet.map((offenceCode) => ({
-    cjsCode: offenceCode["CJS Offence Code"],
-    offenceTitle: consistentWhitespace(offenceCode["Offence Title"])?.replace("&amp;", "&"),
-    recordableOnPnc: valueToBoolean(offenceCode["Recordable On PNC Indicator"]),
-    offenceCategory: offenceCode["Offence Category Code"]
-  }))
+  return jsonWorksheet
+    .filter((offenceCode) => /^[a-zA-Z0-9]+$/.test(offenceCode["CJS Offence Code"]))
+    .map((offenceCode) => ({
+      cjsCode: offenceCode["CJS Offence Code"],
+      offenceTitle: consistentWhitespace(offenceCode["Offence Title"])?.replace("&amp;", "&"),
+      recordableOnPnc: valueToBoolean(offenceCode["Recordable On PNC Indicator"]),
+      offenceCategory: offenceCode["Offence Category Code"]
+    }))
 }

--- a/src/cjs-download/index.ts
+++ b/src/cjs-download/index.ts
@@ -6,7 +6,7 @@ import getDownloadUrl from "./getDownloadUrl"
 
 export default async () => {
   console.log("Downloading CJS data")
-  const downloadLinkRegex = /(https:\/\/.*offence.*cjs.*index.*ods)"/i
+  const downloadLinkRegex = /(https:\/\/.*offence.*cjs.*index.*csv)"/i
   const downloadLocation = await getDownloadUrl(downloadLinkRegex)
   const fileContents = await downloadFile(downloadLocation)
   const offenceCodes = convertOds(fileContents)


### PR DESCRIPTION
The CJS offence codes spreadsheet on https://www.gov.uk/guidance/criminal-justice-system-data-standards-forum-guidance only have CSV now so we've updated this.

The CSV also included some invalid value at the bottom of the spreadsheet so I've added a very basic regex to filter only for valid ones.

![image](https://github.com/user-attachments/assets/9f4ce078-c58c-4f79-a26a-884c2ec50ea5)
