### PR TITLE
BICAWS7-4122 Pin workflows to SHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,13 +21,13 @@ jobs:
       version: ${{ steps.bump.outputs.version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6
         with:
           token: ${{ secrets.GH_ACCESS_TOKEN }}
           persist-credentials: true
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6
         with:
           node-version-file: .nvmrc
 
@@ -55,17 +55,18 @@ jobs:
       - name: Push new commit and tag
         run: git push --follow-tags
 
-      - name: Report Status
-        if: always()
-        uses: ravsamhq/notify-slack-action@v1
-        with:
-          status: ${{ job.status }}
-          notification_title: "GitHub action failed: Bump package version"
-          message_format: ":elmo-fire: *{workflow}* {status_message} in <{repo_url}|{repo}>"
-          notify_when: "failure"
-          footer: "Linked to Repo <{repo_url}|{repo}>"
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
+# Temporarily disabled - investigating alternative actions
+#      - name: Report Status
+#        if: always()
+#        uses: ravsamhq/notify-slack-action@4ed28566c2bdcdaee6dca2b46b9666d01b4ed8a4 # v1
+#        with:
+#          status: ${{ job.status }}
+#          notification_title: "GitHub action failed: Bump package version"
+#          message_format: ":elmo-fire: *{workflow}* {status_message} in <{repo_url}|{repo}>"
+#          notify_when: "failure"
+#          footer: "Linked to Repo <{repo_url}|{repo}>"
+#        env:
+#          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
 
   release-npm-package:
     name: Release NPM package
@@ -73,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6
         with:
           # We need to specify the branch name, so that we get the updated package.json
           # If we don't specify this, the default is to fetch the commit that triggered
@@ -81,18 +82,18 @@ jobs:
           ref: ${{ github.ref_name }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6
         with:
           node-version-file: .nvmrc
 
       - name: Install top-level NPM dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Generate triggers.properties files
         run: npm run generate-trigger-config
 
       - name: Install output package NPM dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
         working-directory: output-data
 
       - name: Build output package
@@ -103,17 +104,18 @@ jobs:
         run: npm publish
         working-directory: output-data
 
-      - name: Report Status
-        if: always()
-        uses: ravsamhq/notify-slack-action@v1
-        with:
-          status: ${{ job.status }}
-          notification_title: "GitHub action failed: Release npm package"
-          message_format: ":elmo-fire: *{workflow}* {status_message} in <{repo_url}|{repo}>"
-          notify_when: "failure"
-          footer: "Linked to Repo <{repo_url}|{repo}>"
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
+# Temporarily disabled - investigating alternative actions
+#      - name: Report Status
+#        if: always()
+#        uses: ravsamhq/notify-slack-action@4ed28566c2bdcdaee6dca2b46b9666d01b4ed8a4 # v1
+#        with:
+#          status: ${{ job.status }}
+#          notification_title: "GitHub action failed: Release npm package"
+#          message_format: ":elmo-fire: *{workflow}* {status_message} in <{repo_url}|{repo}>"
+#          notify_when: "failure"
+#          footer: "Linked to Repo <{repo_url}|{repo}>"
+#        env:
+#          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
 
   release-maven-package:
     name: Release Maven package
@@ -121,7 +123,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6
         with:
           # We need to specify the branch name, so that we get the updated package.json
           # If we don't specify this, the default is to fetch the commit that triggered
@@ -129,18 +131,18 @@ jobs:
           ref: ${{ github.ref_name }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6
         with:
           node-version-file: .nvmrc
 
       - name: Install top-level NPM dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Generate triggers.properties files
         run: npm run generate-trigger-config
 
       - name: Setup Java and Maven
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5
         with:
           distribution: "zulu"
           java-version: 17
@@ -162,17 +164,18 @@ jobs:
           MAVEN_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
 
-      - name: Report Status
-        if: always()
-        uses: ravsamhq/notify-slack-action@v1
-        with:
-          status: ${{ job.status }}
-          notification_title: "GitHub action failed: Release Maven package"
-          message_format: ":elmo-fire: *{workflow}* {status_message} in <{repo_url}|{repo}>"
-          notify_when: "failure"
-          footer: "Linked to Repo <{repo_url}|{repo}>"
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
+# Temporarily disabled - investigating alternative actions
+#      - name: Report Status
+#        if: always()
+#        uses: ravsamhq/notify-slack-action@4ed28566c2bdcdaee6dca2b46b9666d01b4ed8a4 # v1
+#        with:
+#          status: ${{ job.status }}
+#          notification_title: "GitHub action failed: Release Maven package"
+#          message_format: ":elmo-fire: *{workflow}* {status_message} in <{repo_url}|{repo}>"
+#          notify_when: "failure"
+#          footer: "Linked to Repo <{repo_url}|{repo}>"
+#        env:
+#          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
 
   update-core-repo:
     name: Update NPM package in core repo
@@ -182,31 +185,32 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out core repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6
         with:
           repository: ministryofjustice/bichard7-next-core
           token: ${{ secrets.GH_ACCESS_TOKEN }}
 
       - name: Update standing data npm package
-        run: npm install @moj-bichard7-developers/bichard7-next-data@${VERSION} -w packages/core -w packages/ui -w packages/e2e-test -w packages/api  -w packages/conductor
+        run: npm install @moj-bichard7-developers/bichard7-next-data@${VERSION} --ignore-scripts -w packages/core -w packages/ui -w packages/e2e-test -w packages/api  -w packages/conductor
         env:
           VERSION: ${{ needs.bump-package-version.outputs.version }}
 
-      - name: Report Status
-        if: always()
-        uses: ravsamhq/notify-slack-action@v1
-        with:
-          status: ${{ job.status }}
-          notification_title: "GitHub action failed: Update core repo"
-          message_format: ":elmo-fire: *{workflow}* {status_message} in <{repo_url}|{repo}>"
-          notify_when: "failure"
-          footer: "Linked to Repo <{repo_url}|{repo}>"
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
+# Temporarily disabled - investigating alternative actions
+#      - name: Report Status
+#        if: always()
+#        uses: ravsamhq/notify-slack-action@4ed28566c2bdcdaee6dca2b46b9666d01b4ed8a4 # v1
+#        with:
+#          status: ${{ job.status }}
+#          notification_title: "GitHub action failed: Update core repo"
+#          message_format: ":elmo-fire: *{workflow}* {status_message} in <{repo_url}|{repo}>"
+#          notify_when: "failure"
+#          footer: "Linked to Repo <{repo_url}|{repo}>"
+#        env:
+#          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
 
       - name: Create pull request
         id: cpr
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 # v8
         with:
           branch: auto/update-standing-data
           delete-branch: true
@@ -233,7 +237,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6
         with:
           repository: ministryofjustice/bichard7-next
           token: ${{ secrets.GH_ACCESS_TOKEN }}
@@ -244,21 +248,22 @@ jobs:
         env:
           VERSION: ${{ needs.bump-package-version.outputs.version }}
 
-      - name: Report Status
-        if: always()
-        uses: ravsamhq/notify-slack-action@v1
-        with:
-          status: ${{ job.status }}
-          notification_title: "GitHub action failed: Update Bichard 7 next"
-          message_format: ":elmo-fire: *{workflow}* {status_message} in <{repo_url}|{repo}>"
-          notify_when: "failure"
-          footer: "Linked to Repo <{repo_url}|{repo}>"
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
+# Temporarily disabled - investigating alternative actions
+#      - name: Report Status
+#        if: always()
+#        uses: ravsamhq/notify-slack-action@v1
+#        with:
+#          status: ${{ job.status }}
+#          notification_title: "GitHub action failed: Update Bichard 7 next"
+#          message_format: ":elmo-fire: *{workflow}* {status_message} in <{repo_url}|{repo}>"
+#          notify_when: "failure"
+#          footer: "Linked to Repo <{repo_url}|{repo}>"
+#        env:
+#          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
 
       - name: Create pull request
         id: cpr
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 # v8
         with:
           branch: auto/update-standing-data
           delete-branch: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,7 +142,7 @@ jobs:
         run: npm run generate-trigger-config
 
       - name: Setup Java and Maven
-        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5
+        uses: actions/setup-java@8764a52df183aa0ccea74521dfd9d506ffc7a19a # v2
         with:
           distribution: "zulu"
           java-version: 17

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,17 +10,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6
         with:
           node-version-file: .nvmrc
 
       - name: Install NPM packages
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Run tests
         run: npm test

--- a/.github/workflows/update-npm-deps.yml
+++ b/.github/workflows/update-npm-deps.yml
@@ -14,34 +14,38 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6
 
       - name: Setup node version
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6
         with:
           node-version-file: .nvmrc
 
+      - name: ⛓️ SLSA Supply Chain Security
+        uses: ministryofjustice/devsecops-actions/sca/slsa@559ec2408860d9237cc472a5710e61c1c2187ffa # v1.4.0
+
       - name: Install dependencies
-        run: npm install
+        run: npm ci --ignore-scripts
 
       - name: Update dependencies
         run: npm run update-deps
 
-      - name: Report Status
-        if: always()
-        uses: ravsamhq/notify-slack-action@v1
-        with:
-          status: ${{ job.status }}
-          notification_title: 'GitHub action failed'
-          message_format: ':elmo-fire: *{workflow}* {status_message} in <{repo_url}|{repo}>'
-          notify_when: 'failure'
-          footer: 'Linked to Repo <{repo_url}|{repo}>'
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
+      # Temporarily disabled - investigating alternative actions
+#      - name: Report Status
+#        if: always()
+#        uses: ravsamhq/notify-slack-action@v1
+#        with:
+#          status: ${{ job.status }}
+#          notification_title: 'GitHub action failed'
+#          message_format: ':elmo-fire: *{workflow}* {status_message} in <{repo_url}|{repo}>'
+#          notify_when: 'failure'
+#          footer: 'Linked to Repo <{repo_url}|{repo}>'
+#        env:
+#          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
 
       - name: Create pull request
         id: cpr
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 # v8
         with:
           branch: auto/update-npm-deps
           delete-branch: true

--- a/.github/workflows/update-npm-deps.yml
+++ b/.github/workflows/update-npm-deps.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Update dependencies
         run: npm run update-deps
 
-      # Temporarily disabled - investigating alternative actions
+# Temporarily disabled - investigating alternative actions
 #      - name: Report Status
 #        if: always()
 #        uses: ravsamhq/notify-slack-action@v1

--- a/.github/workflows/update-standing-data.yml
+++ b/.github/workflows/update-standing-data.yml
@@ -21,15 +21,15 @@ jobs:
       HEADLESS: "true"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6
 
       - name: Setup node version
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6
         with:
           node-version-file: .nvmrc
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci --ignore-scripts
 
       - name: Download offence code data files
         run: npm run download-offence-code-data
@@ -49,21 +49,22 @@ jobs:
       - name: Merge CJS result codes data files
         run: npm run merge-cjs-result-codes-data
 
-      - name: Report Status
-        if: always()
-        uses: ravsamhq/notify-slack-action@v1
-        with:
-          status: ${{ job.status }}
-          notification_title: "GitHub action failed"
-          message_format: ":elmo-fire: *{workflow}* {status_message} in <{repo_url}|{repo}>"
-          notify_when: "failure"
-          footer: "Linked to Repo <{repo_url}|{repo}>"
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
+# Temporarily disabled - investigating alternative actions
+#      - name: Report Status
+#        if: always()
+#        uses: ravsamhq/notify-slack-action@4ed28566c2bdcdaee6dca2b46b9666d01b4ed8a4 # v1
+#        with:
+#          status: ${{ job.status }}
+#          notification_title: "GitHub action failed"
+#          message_format: ":elmo-fire: *{workflow}* {status_message} in <{repo_url}|{repo}>"
+#          notify_when: "failure"
+#          footer: "Linked to Repo <{repo_url}|{repo}>"
+#        env:
+#          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}
 
       - name: Create pull request
         id: cpr
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@98357b18bf14b5342f975ff684046ec3b2a07725 # v8
         with:
           branch: auto/update-data
           delete-branch: true


### PR DESCRIPTION
This PR pins workflow steps to SHA instead of tags wherever possible

It temporarily disables the Slack notifications action step while we look for an alternatives