### PR TITLE
Use older version of ts-jest to fix SLSA issue

### DIFF
--- a/output-data/package.json
+++ b/output-data/package.json
@@ -24,7 +24,7 @@
     "@emnapi/wasi-threads": "^1.2.1",
     "jest": "^30.4.2",
     "jest-extended": "^2.0.0",
-    "ts-jest": "^29.4.11",
+    "ts-jest": "^29.4.9",
     "typescript": "^4.5.5"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "prettier": "^3.8.3",
     "puppeteer": "^25.1.0",
     "sort-json-keys": "^1.0.3",
-    "ts-jest": "^29.4.11",
+    "ts-jest": "^29.4.9",
     "ts-node": "^10.9.2",
     "typescript": "^6.0.3",
     "uuid": "^14.0.0",


### PR DESCRIPTION
Using an older version of ts-jest so it doesn't get flagged by SLSA - This will get bumped on Monday when the npm update automation runs. By then, the quarantine time for SLSA would of lapsed   

---

<img width="802" height="777" alt="image" src="https://github.com/user-attachments/assets/42fcbc94-c802-489c-ab3e-6dd124fd943d" />

